### PR TITLE
Develop: media queries for phones added

### DIFF
--- a/style.css
+++ b/style.css
@@ -195,7 +195,27 @@ body {
     transform: translate(-50%, -50%) scale(75%);
   }
 
-  .info-text {
+  .info-text,
+  .btn-speed {
     font-size: 2rem;
+  }
+}
+
+@media (orientation: landscape) {
+  body {
+    height: 100vw;
+    transform: rotate(90deg);
+  }
+
+  .header,
+  .sub-header,
+  .speed-btn-container {
+    width: 100vh;
+  }
+
+  .simon,
+  .info-text,
+  .score {
+    left: 50vh;
   }
 }

--- a/style.css
+++ b/style.css
@@ -189,3 +189,13 @@ body {
 
   transition: all 0.3s;
 }
+
+@media (max-width: 415px) or (max-height: 715px) {
+  .simon {
+    transform: translate(-50%, -50%) scale(75%);
+  }
+
+  .info-text {
+    font-size: 2rem;
+  }
+}


### PR DESCRIPTION
Added media queries for phones. This should keep everything balanced on screen for most popular phone sizes. Landscape mode simply maintains the positions of all elements in portrait mode. This should motivate the user to stay in portrait mode, although it is now playable in landscape as well.